### PR TITLE
大佬，发现您的项目引入了org.apache.cxf:cxf-rt-transports-http@3.1.6组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -80,7 +78,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>3.1.6</version>
+            <version>3.3.8</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache CXF 安全特征问题漏洞
缺陷组件：org.apache.cxf:cxf-rt-transports-http@3.1.6
漏洞编号：CVE-2018-8039
漏洞描述：Apache CXF是美国阿帕奇（Apache）基金会的一个开源的Web服务框架。该框架支持多种Web服务标准、多种前端编程API等。
Apache CXF 3.1.16之前版本和3.2.0版本至3.2.5版本（不包括3.2.5版本）中存在安全特征问题漏洞。该漏洞是源于网络系统或产品中缺少身份验证、访问控制、权限管理等安全措施。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2018-12672
影响范围：(∞, 3.1.16)
最小修复版本：3.3.8
缺陷组件引入路径：com.daisx:heaven@1.0->org.apache.cxf:cxf-rt-transports-http@3.1.6
```
另外我运行这个项目时，IDE的安全插件提示还有24个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p11b34